### PR TITLE
Attempt to port to current versions

### DIFF
--- a/ws2812-avr/Cargo.toml
+++ b/ws2812-avr/Cargo.toml
@@ -17,5 +17,5 @@ attiny85 = []
 attiny88 = []
 
 [dependencies]
-avr-hal-generic = {git = "https://github.com/rahix/avr-hal", rev = "1aacefb335517f85d0de858231e11055d9768cdf"}
-arduino-hal = {git = "https://github.com/rahix/avr-hal", rev = "1aacefb335517f85d0de858231e11055d9768cdf"}
+avr-hal-generic = {git = "https://github.com/rahix/avr-hal", rev = "3e362624547462928a219c40f9ea8e3a64f21e5f"}
+arduino-hal = {git = "https://github.com/rahix/avr-hal", rev = "3e362624547462928a219c40f9ea8e3a64f21e5f"}

--- a/ws2812-avr/src/lib.rs
+++ b/ws2812-avr/src/lib.rs
@@ -25,6 +25,8 @@ along with ws2812-avr. If not, see <https://www.gnu.org/licenses/>.
 #![feature(adt_const_params)]
 #![feature(const_trait_impl)]
 #![feature(const_slice_index)]
+#![feature(effects)]
+
 mod color;
 mod ports;
 pub mod util;

--- a/ws2812-avr/src/util/const_str.rs
+++ b/ws2812-avr/src/util/const_str.rs
@@ -20,6 +20,7 @@ along with ws2812-avr. If not, see <https://www.gnu.org/licenses/>.
  * currently used for construct diagnostic strings that can be used to
  * panic in const evaluation, for showing informative messages to the
  * user. */
+#[const_trait]
 trait CopyFromSliceConst<A> {
     fn const_copy_from_slice(&mut self, other: &[A]);
 }
@@ -65,11 +66,11 @@ pub struct ConstStr<const LEN: usize> {
     data: [u8; LEN],
 }
 
-impl<const LEN: usize> const AsRef<str> for ConstStr<LEN> {
-    fn as_ref(&self) -> &str {
-        unsafe { core::str::from_utf8_unchecked(&self.data) }
-    }
-}
+// impl<const LEN: usize> const AsRef<str> for ConstStr<LEN> {
+//     fn as_ref(&self) -> &str {
+//         unsafe { core::str::from_utf8_unchecked(&self.data) }
+//     }
+// }
 
 impl ConstStr<0> {
     /**


### PR DESCRIPTION
Hi, i updated the rev of the `avr-hal` dependency to a more recent one. This works well for me in my tests with an arduino uno and an arduino mega. This required me also to add another feature use, because my installed rust-cargo version is `cargo 1.79.0-nightly (d438c80c4 2024-03-19)`. I had to remove a util function in the const_str.rs that is seemingly not relevant for the leds to work. Please let me know if im wrong about this!